### PR TITLE
Pass API key to IAS client

### DIFF
--- a/service/kbupd/src/frontend/mod.rs
+++ b/service/kbupd/src/frontend/mod.rs
@@ -89,7 +89,7 @@ impl FrontendService {
                 })
                 .context("error creating intel attestation tls proxy client")?;
             let new_intel_client =
-                new_ias_client(&config.attestation.host, intel_client_proxy).context("error creating intel attestation client")?;
+                new_ias_client(&config.attestation.host, &config.attestation.apiKey, intel_client_proxy).context("error creating intel attestation client")?;
             handshake_manager = Some(HandshakeManager::new(
                 enclave_manager_tx.clone(),
                 new_intel_client.clone(),

--- a/service/kbupd/src/intel_client.rs
+++ b/service/kbupd/src/intel_client.rs
@@ -13,11 +13,11 @@ use kbuptlsd::prelude::*;
 
 pub type KbupdIasClient = IasClient<TlsProxyConnector<HttpConnector>>;
 
-pub fn new_ias_client(host: &str, tls_proxy: TlsClientProxySpawner) -> Result<KbupdIasClient, failure::Error> {
+pub fn new_ias_client(host: &str, api_key: &str, tls_proxy: TlsClientProxySpawner) -> Result<KbupdIasClient, failure::Error> {
     let mut http_connector = HttpConnector::new(1);
     http_connector.enforce_http(false);
 
     let tls_connector = TlsProxyConnector::new(Arc::new(tls_proxy), http_connector);
 
-    IasClient::new(host, Some(IasApiVersion::ApiVer3), None, tls_connector)
+    IasClient::new(host, Some(IasApiVersion::ApiVer3), Some(api_key), tls_connector)
 }

--- a/service/kbupd/src/main.rs
+++ b/service/kbupd/src/main.rs
@@ -82,6 +82,7 @@ fn run(arguments: clap::ArgMatches<'static>) -> Result<(), failure::Error> {
             set_argument(  &mut config.attestation.tlsConfigPath,           arguments.value_of("ias_tls_config_file").map(Path::new));
             set_argument(  &mut config.attestation.disabled,                Some(!arguments.is_present("ias_tls_config_file")).filter(|present| !*present));
             set_argument(  &mut config.attestation.host,                    arguments.value_of("ias_host"));
+            set_argument(  &mut config.attestation.apiKey,                  arguments.value_of("ias_api_key"));
             parse_argument(&mut config.attestation.spid,                    arguments.value_of("ias_spid"), hex::parse_fixed).context("invalid --ias-spid")?;
             set_argument(  &mut config.control.listenHostPort,              arguments.value_of("control_listen_address"));
             set_argument(  &mut config.enclave.mrenclave,                   subcommand_arguments.value_of("enclave_filename"));
@@ -155,6 +156,7 @@ fn run(arguments: clap::ArgMatches<'static>) -> Result<(), failure::Error> {
             set_argument(  &mut config.attestation.tlsConfigPath,               arguments.value_of("ias_tls_config_file").map(Path::new));
             set_argument(  &mut config.attestation.disabled,                    Some(!arguments.is_present("ias_tls_config_file")).filter(|present| !*present));
             set_argument(  &mut config.attestation.host,                        arguments.value_of("ias_host"));
+            set_argument(  &mut config.attestation.apiKey,                      arguments.value_of("ias_api_key"));
             parse_argument(&mut config.attestation.spid,                        arguments.value_of("ias_spid"), hex::parse_fixed).context("invalid --ias-spid")?;
 
             set_argument(  &mut config.control.listenHostPort, arguments.value_of("control_listen_address"));

--- a/service/kbupd/src/replica/mod.rs
+++ b/service/kbupd/src/replica/mod.rs
@@ -81,7 +81,7 @@ impl ReplicaService {
                     key_file:    None,
                 })
                 .context("error creating intel attestation tls client proxy")?;
-            Some(new_ias_client(&config.attestation.host, intel_client_proxy).context("error creating intel attestation client")?)
+            Some(new_ias_client(&config.attestation.host, &config.attestation.apiKey, intel_client_proxy).context("error creating intel attestation client")?)
         } else {
             None
         };

--- a/service/kbupd_config/src/frontend/config.rs
+++ b/service/kbupd_config/src/frontend/config.rs
@@ -71,6 +71,8 @@ pub struct FrontendAttestationConfig {
     #[serde(with = "hex::SerdeFixedLengthHex")]
     pub spid: [u8; 16],
 
+    pub apiKey: String,
+
     pub tlsConfigPath: PathBuf,
 
     #[serde(default)]

--- a/service/kbupd_config/src/replica/config.rs
+++ b/service/kbupd_config/src/replica/config.rs
@@ -31,6 +31,8 @@ pub struct ReplicaConfig {
 pub struct ReplicaAttestationConfig {
     pub host: String,
 
+    pub apiKey: String,
+
     #[serde(with = "hex::SerdeFixedLengthHex")]
     pub spid: [u8; 16],
 


### PR DESCRIPTION
Hi,

When trying to setup the service with IAS these days, it seems that Intel has another dev endpoint which requires api key to work. Passing `None` to the new endpoint comes out a non-existent API path.  Related [document](https://api.trustedservices.intel.com/documents/sgx-attestation-api-spec.pdf) can be found [here](https://api.portal.trustedservices.intel.com/EPID-attestation).

Changes in this PR had helped me start running a replica and its peering frontend with Intel's development environment.  
However this is my first time coding in Rust, I am not sure if there're better practices that I should follow.

Please kindly take this as a notice about the IAS endpoint change and a proven work reference, and consider merge (with or without modify) if this helps.

Cheers,
Tso-Shuo Tsao